### PR TITLE
feat(options): add support for using an options file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ More info about [pub-run](https://dart.dev/tools/pub/cmd/pub-run) and [build_run
 ### Options
 
 ```yaml
-# Specify an assets_gen section in pubspec.yaml
+# Specify an assets_gen section in pubspec.yaml or assets_gen.yaml
 flutter:
   assets:
     - path/to/asset

--- a/lib/src/const.dart
+++ b/lib/src/const.dart
@@ -1,2 +1,2 @@
-// const String options_file = 'assets_gen_options.yaml';
+const String optionsFile = 'assets_gen.yaml';
 const String pubspecFile = 'pubspec.yaml';

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -26,6 +26,9 @@ class PubSpec {
   /// pubspec.yaml file path
   String get pubspecPath => p.join(path, pubspecFile);
 
+  /// assets_gen.yaml file path
+  String get optionsPath => p.join(path, optionsFile);
+
   PubSpec.parse(File f) {
     path = p.normalize(f.parent.path);
     update();
@@ -60,24 +63,28 @@ class PubSpec {
     final assetsGen = yaml['assets_gen'];
     if (assetsGen is YamlMap) {
       options.update(assetsGen);
+      return;
     }
 
-    // // update from options file
-    // File optionsFile = File(p.join(path, options_file));
-    // if (!optionsFile.existsSync()) {
-    //   return;
-    // }
-    // final optionsYaml = loadYaml(optionsFile.readAsStringSync());
-    // if (optionsYaml == null || optionsYaml.isEmpty) {
-    //   logger.info('$options_file is empty.');
-    //   return;
-    // }
-    // if (optionsYaml is! YamlMap) {
-    //   logger.warning(
-    //       '$options_file(${optionsYaml.runtimeType}) is not map format.');
-    //   return;
-    // }
-    // options.update(optionsYaml.value);
+    _parseOptionsFromFile();
+  }
+
+  void _parseOptionsFromFile() {
+    File optionsFile = File(optionsPath);
+    if (!optionsFile.existsSync()) {
+      return;
+    }
+    final optionsYaml = loadYaml(optionsFile.readAsStringSync());
+    if (optionsYaml == null || optionsYaml.isEmpty) {
+      logger.info('$optionsFile is empty.');
+      return;
+    }
+    if (optionsYaml is! YamlMap) {
+      logger.warning(
+          '$optionsFile(${optionsYaml.runtimeType}) is not map format.');
+      return;
+    }
+    options.update(optionsYaml['assets_gen']);
   }
 
   @override


### PR DESCRIPTION
## Description

Add support for using an options file instead of just the pubspec options. I basically updated the code that already existed and was just commented on. 

## How to test

Create an `assets_gen.yaml` file with your specific configs and then run:

```cli
flutter pub run assets_gen build
```